### PR TITLE
Fix blurring live feed background

### DIFF
--- a/fake_webcam_background.py
+++ b/fake_webcam_background.py
@@ -206,8 +206,8 @@ while True:
             continue
         elif blur_background_value:
             replacement_bgs = frame
-            replacement_bgs = cv2.blur(replacement_bgs,
-                (blur_background_value, blur_background_value))
+            replacement_bgs = [cv2.blur(replacement_bgs,
+                (blur_background_value, blur_background_value))]
 
     img = Image.fromarray(frame)
     imgWidth, imgHeight = img.size


### PR DESCRIPTION
The replacement background images are normally loaded as a list, but when not using images the frame was not stored as a list.